### PR TITLE
Pin Bundler version for Ruby 3 tests to fix Bundler version failure

### DIFF
--- a/.github/workflows/rspec_tests.yml
+++ b/.github/workflows/rspec_tests.yml
@@ -67,7 +67,7 @@ jobs:
         run: mv -f Gemfile.AR7 Gemfile
       - name: Bundle Install
         run: |
-          gem install bundler
+          gem install bundler:2.3.21
           bundle install
         env:
           FORCED_BUNDLER_VERSION: 2.3.21


### PR DESCRIPTION
Bundler fails during Ruby 3 testing as it was not pinned and a new patch version has been released