### PR TITLE
Increase Rubocop allowed class length to 150

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
   TargetRubyVersion: 2.4
 
 Metrics/ClassLength: 
-  Max: 120
+  Max: 150
 Metrics/MethodLength: 
   Max: 20
 RSpec/ExampleLength:


### PR DESCRIPTION
Increase Rubocop allowed class length as attribute.rb is beyond the limit and can't be nicely split - perhaps it can be refactored at a later point and this value can be decreased